### PR TITLE
コメント機能をAjax化し、フォームを非同期表示に変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'devise'
 gem 'faker'
 gem 'hamlit'
 gem 'aws-sdk-s3', require: false
+gem 'active_model_serializers'
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,11 @@ GEM
       rails-html-sanitizer (~> 1.6)
     active_decorator (1.5.1)
       activesupport
+    active_model_serializers (0.10.16)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (8.0.2)
       activesupport (= 8.0.2)
       globalid (>= 0.3.6)
@@ -123,6 +128,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
@@ -204,6 +211,7 @@ GEM
       activesupport (>= 5.0.0)
     jmespath (1.6.2)
     json (2.12.2)
+    jsonapi-renderer (0.2.2)
     kamal (2.6.1)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -455,6 +463,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_decorator
+  active_model_serializers
   aws-sdk-s3
   better_errors
   binding_of_caller

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,10 @@
 class CommentsController < ApplicationController
+    def index
+      article = Article.find(params[:article_id])
+      comments = article.comments
+      render json: comments
+    end
+
     def new
       article = Article.find(params[:article_id])
       @comment = article.comments.build
@@ -7,13 +13,14 @@ class CommentsController < ApplicationController
     def create
       article = Article.find(params[:article_id])
       @comment = article.comments.build(comment_params)
+
       if @comment.save
-        redirect_to article_path(article), notice: 'コメントを追加'
+        render json: @comment
       else
-        flash.now[:error] = '更新できませんでした'
-        render :new
+        render json: { error: '保存失敗' }, status: :unprocessable_entity
       end
     end
+
   
     private
     def comment_params

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -1,0 +1,3 @@
+class CommentSerializer < ActiveModel::Serializer
+  attributes :id, :content
+end

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -26,11 +26,9 @@
 
 .article
   %h2 コメント一覧
-  - @comments.each do |comment|
-    .article_comment
-      %p= comment.content
+  .comments-container
 
 .container
-  = link_to new_article_comment_path(@article) do
-    .btn-secondary
-      コメントを追加
+  .comment-form-container
+  = link_to "#", class: "btn-secondary", id: "comment-toggle" do
+    コメントを追加

--- a/app/views/comments/new.html.haml
+++ b/app/views/comments/new.html.haml
@@ -3,7 +3,10 @@
     - @comment.errors.full_messages.each do |message|
       %li= message
 
-  = form_with(model: @comment, url: article_comments_path(@comment.article), local: true) do |f|
+  = form_with(model: @comment,
+            url: article_comments_path(@comment.article),
+            id: "comment-form",
+            data: { turbo: false }) do |f|
     %div
       = f.label :content, '内容'
     %div

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   resource :timeline, only: [:show]
 
   resources :articles do
-    resources :comments, only: [:new, :create]
+    resources :comments, only: [:index, :new, :create]
     resource :like, only: [:show, :create, :destroy]
   end
 


### PR DESCRIPTION
- Ajaxを用いて、ページをリロードせずにコメントの取得・投稿を行えるように変更
- コメント一覧はfetch APIを用いて非同期で取得し、DOMへ描画する構成へ変更
- 投稿処理もredirectからJSONレスポンスへ変更し、投稿成功時に即時反映するよう実装
- また、Serializerを用いることで返却するJSON構造を明確に制御
- 教材で実装しているjQueryは使用せず、Rails8の標準構成に合わせてfetchで実装

Ajax：「ページをリロードせずに、サーバーとデータのやり取りをする仕組み」
fetch：ブラウザ標準のHTTP通信API（教材はaxios）
Serializer：モデルのデータをJSON形式に整形する