### PR TITLE
メール送付（Mailer）とコールバック

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem 'faker'
 gem 'hamlit'
 gem 'aws-sdk-s3', require: false
 gem 'active_model_serializers'
+gem 'letter_opener'
+gem 'letter_opener_web', '~> 3.0'
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
       xpath (~> 3.2)
     case_transform (0.2)
       activesupport
+    childprocess (5.1.0)
+      logger (~> 1.5)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
@@ -224,6 +226,17 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -482,6 +495,8 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  letter_opener
+  letter_opener_web (~> 3.0)
   pg (>= 0.18, < 2.0)
   propshaft (~> 1.0)
   pry

--- a/app/mailers/relationship_mailer.rb
+++ b/app/mailers/relationship_mailer.rb
@@ -1,0 +1,10 @@
+class RelationshipMailer < ApplicationMailer
+  def new_follower(user, follower)
+    @user = user
+    @follower = follower
+
+    mail(to: @user.email, subject: '[お知らせ] フォローされました') do |format|
+      format.html
+    end
+  end
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,4 +1,11 @@
 class Relationship < ApplicationRecord
     belongs_to :follower, class_name: 'User'
     belongs_to :following, class_name: 'User'
+
+  after_create :send_email
+
+  private
+  def send_email
+    RelationshipMailer.new_follower(following, follower).deliver_now
+  end
 end

--- a/app/views/relationship_mailer/new_follower.html.haml
+++ b/app/views/relationship_mailer/new_follower.html.haml
@@ -1,0 +1,4 @@
+%p #{@user.email} さん
+%p 以下のユーザにフォローされました。
+
+= link_to 'プロフィールを確認する', account_url(@follower)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,6 +39,8 @@ Rails.application.configure do
 
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
+
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'articles#index'


### PR DESCRIPTION
・ActionMailerを使ったフォロー通知メール機能の実装
・RelationshipMailerを作成し、new_followerメソッドでメール送信処理を記述
・メールテンプレートを作成し、HTML形式で表示
・メール内リンクでは、_pathではなく絶対URLを返す_urlを使用
　users_path => '/users'
　users_url => 'http://localhost:3000/users'
・Relationshipモデルにafter_createコールバックを追加し、フォロー作成後に自動送信する仕組みの実装
・コールバックの実行順（validation → create → commit）の整理と、保存後に処理が実行される流れの確認
・開発環境でletter_openerを設定し、ブラウザ上でのメール内容確認